### PR TITLE
Fixing some Errors

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -128,7 +128,7 @@ PROCESSING_CONFIG = {
 # --- API Configuration ---
 API_CONFIG = {
     "host": "0.0.0.0",
-    "port": 5000,
+    "port": 5001,
     "debug": True,
     "cors_enabled": True
 }

--- a/frontend/streamlit_app.py
+++ b/frontend/streamlit_app.py
@@ -289,7 +289,7 @@ if selected_location in location_coords:
 # Add data source information
 with st.sidebar.expander("Data Sources"):
     try:
-        sources_res = requests.get("http://localhost:5000/api/data-sources", timeout=2)
+        sources_res = requests.get("http://localhost:5001/api/data-sources", timeout=2)
         if sources_res.status_code == 200:
             sources_data = sources_res.json()
             for source_name, source_info in sources_data.items():
@@ -314,7 +314,7 @@ if st.sidebar.button("Download Data"):
     st.sidebar.info(f"Downloading data for {selected_location}")
     with st.spinner(f"Downloading data for {bounds_info['description']}..."):
         try:
-            download_res = requests.post("http://localhost:5000/api/download-data", json=download_payload)
+            download_res = requests.post("http://localhost:5001/api/download-data", json=download_payload)
             if download_res.status_code == 200:
                 download_data = download_res.json()
                 st.success(f"Data downloaded for {selected_location}")
@@ -338,7 +338,7 @@ if st.sidebar.button("Run Prediction"):
     st.sidebar.info(f"Running prediction for {selected_location}")
     with st.spinner(f"Running Aurora model for {bounds_info['description']}..."):
         try:
-            res = requests.post("http://localhost:5000/api/predict_oceanic", json=payload)
+            res = requests.post("http://localhost:5001/api/predict_oceanic", json=payload)
             if res.status_code == 200:
                 st.session_state["prediction"] = res.json()
                 st.success(f"Wave prediction completed for {selected_location}")
@@ -417,7 +417,7 @@ with col2:
 
     # Add backend status check
     try:
-        health_res = requests.get("http://localhost:5000/api/health", timeout=2)
+        health_res = requests.get("http://localhost:5001/api/health", timeout=2)
         if health_res.status_code == 200:
             st.success("Backend Online")
             health_data = health_res.json()


### PR DESCRIPTION
Issue #1 (minor): changing port from 5000 to 5001 because Apple has some issues with it (something related to AirPlay).
Issue #2 (major): in original code, the oldest two time steps in the 30-day range of downloaded data were being used (which means all predictions are based on data that are a month old). Just changed the indexing from data[2:] to data[-2:] to take the most recent two time steps.


Some extra things we could consider:
- Do we actually need to download 30 days worth of data when the user wants to run a prediction? Or can we just download the bare minimum to get the most recent two time steps?
- Should we limit the user from picking a day in the future to download data for? Really simple, just change the Streamlit UI to not allow the user to go in the future in the calendar drop-down.
- On the other hand, for a more intuitive experience, what if the user just picks the day he/she wants the prediction for? If this day is in the past, the website just displays the raw data. If this day is in the future, it uses the most recent data and uses the appropriate number of time steps.
- Add other models for the user to choose from (or find a way to merge the results)